### PR TITLE
chore: 新增星空键道方案/github action 自动测试部署

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: Test Deployment
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build and Deploy
+        run: |
+          bash ./build.sh

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .SharedSupport
 package
 .networm
+.rime_jd

--- a/build.sh
+++ b/build.sh
@@ -59,6 +59,15 @@ rm -rf .networm && \
     rm -rf .git .gitignore README.md rime.lua default.custom.yaml
   ) && cp -R .networm/* ${OUTPUT}
 
+# 星空键道
+# 方案来源: https://github.com/xkinput/Rime_JD
+rm -rf .rime_jd && \
+  bash .plum/scripts/install-packages.sh xkinput/Rime_JD@plum .rime_jd && \
+  cp .rime_jd/xkjd6.*.yaml ${OUTPUT} && \
+  cp .rime_jd/lua/* ${OUTPUT}/lua/ && \
+  cp .rime_jd/opencc/EN2en.* ${OUTPUT}/opencc/ && \
+  echo 'date_time_translator = require("date_time")' >> ${OUTPUT}/rime.lua && \
+  echo 'xkjd6_filter = require("xkjd6_filter")' >> ${OUTPUT}/rime.lua
 
 pushd "${OUTPUT}" > /dev/null
 


### PR DESCRIPTION
#### 新增方案星空键道
我是[星空键道](https://github.com/xkinput/Rime_JD)仓库维护者之一，星空键道是音形结合的码表输入方案，有不少用户使用，希望可以加入仓的默认方案。

星空键道支持东风破安装，为了和其他方案兼容，没有给东风破的安装方式提供 `rime.lua`，用户需要手动在 `rime.lua` 添加两行，对应到这次的改动，就是

```bash
  echo 'date_time_translator = require("date_time")' >> ${OUTPUT}/rime.lua && \
  echo 'xkjd6_filter = require("xkjd6_filter")' >> ${OUTPUT}/rime.lua
```

#### GitHub Actions 自动测试
除此之外，这次改动添加了一个 workflow，在 pull request 和 push 的时候执行自动构建测试，这样可以方便地看到是否能部署成功