### PR TITLE
feat: fetch rime-emoji from upstream (resolve #13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,9 @@ jobs:
       - name: Build and Deploy
         run: |
           bash ./build.sh
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: SharedSupport.zip
+          path: SharedSupport.zip

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,8 @@
 # encoding: utf-8
 set -e
 
+WORK=`pwd`
+
 # 下载已编译过的rimelib
 rime_version=1.8.5
 rime_git_hash=08dd95f
@@ -112,6 +114,28 @@ rm -rf $OUTPUT/.yuhao && \
   echo 'temp = require("yuhao/yuhao_chaifen")' >> ${DST_PATH}/rime.lua
   echo 'yuhao_chaifen = temp.filter' >> ${DST_PATH}/rime.lua
   echo 'yuhao_chaifen_processor = temp.processor' >> ${DST_PATH}/rime.lua
+
+# 绘文字
+# 方案来源: https://github.com/rime/rime-emoji
+rime_emoji_version="15.0"
+rime_emoji_archive="rime-emoji-${rime_emoji_version}.zip"
+rime_emoji_download_url="https://github.com/rime/rime-emoji/archive/refs/tags/${rime_emoji_version}.zip"
+rm -rf $OUTPUT/.emoji && mkdir -p $OUTPUT/.emoji && (
+    cd $OUTPUT/.emoji
+    [ -z "${no_download}" ] && curl -Lo "${rime_emoji_archive}" "${rime_emoji_download_url}"
+    unzip "${rime_emoji_archive}" -d .
+    rm -rf ${rime_emoji_archive}
+    cd rime-emoji-${rime_emoji_version}
+    for target in category word; do
+      ${WORK}/.deps/bin/opencc -c ${WORK}/.deps/share/opencc/t2s.json -i opencc/emoji_${target}.txt > ${target}.txt
+      # workaround for rime/rime-emoji#48
+      # macOS sed 和 GNU sed 不同，见 https://stackoverflow.com/a/4247319/6676742
+      sed -i'.original' -e 's/鼔/鼓/g' ${target}.txt
+      cat ${target}.txt opencc/emoji_${target}.txt | awk '!seen[$1]++' > ../emoji_${target}.txt
+    done
+  ) && \
+cp ${OUTPUT}/.emoji/emoji_*.txt ${DST_PATH}/opencc/ && \
+cp ${OUTPUT}/.emoji/rime-emoji-${rime_emoji_version}/opencc/emoji.json ${DST_PATH}/opencc/
 
 # 整理 DST_PATH 输入方案文件, 生成最终版版本default.yaml
 pushd "${DST_PATH}" > /dev/null


### PR DESCRIPTION
chore: upload SharedSupport.zip as artifact

上游 rime-emoji 的词典是繁体，这个改动在脚本里下载上游文件后，会做以下事情：

1. 将 emoji 词典的中文转为简体另存为文件
2. 合并简体的文件和原始文件，并去除相同的词头

这样复制过去的词典就包含了简体、繁体，且没有重复词头。

另外一个小修改是在 workflow 中添将 SharedSupport.zip 上传到 artifacts 里，方便下载下来检查是否有问题。