### PR TITLE
宇浩输入法的 lua 更新，使用 cat 而非 echo 貼入 rime.lua，避免代碼冗長

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -98,23 +98,13 @@ rm -rf $OUTPUT/.xmjd6 && \
 # 方案来源：https://github.com/forFudan/yuhao
 rm -rf $OUTPUT/.yuhao && \
   git clone --depth 1 https://github.com/forFudan/yuhao $OUTPUT/.yuhao && (
-    cd $OUTPUT/.yuhao/beta/schema
+    cd $OUTPUT/.yuhao/dist/yuhao/schema
     rm -rf default.custom.yaml
   ) &&  \
-  cp $OUTPUT/.yuhao/beta/schema/*.yaml ${DST_PATH} && \
-  cp -r $OUTPUT/.yuhao/beta/schema/lua/* ${DST_PATH}/lua/ && \
+  cp $OUTPUT/.yuhao/dist/yuhao/schema/*.yaml ${DST_PATH} && \
+  cp -r $OUTPUT/.yuhao/dist/yuhao/schema/lua/* ${DST_PATH}/lua/ && \
   echo '' >> ${DST_PATH}/rime.lua && \
-  echo '-- 宇浩输入法' >> ${DST_PATH}/rime.lua && \
-  echo 'yuhao_char_filter = require("yuhao/yuhao_char_filter")' >> ${DST_PATH}/rime.lua && \
-  echo 'yuhao_char_first = yuhao_char_filter.yuhao_char_first' >> ${DST_PATH}/rime.lua && \
-  echo 'yuhao_char_only = yuhao_char_filter.yuhao_char_only' >> ${DST_PATH}/rime.lua && \
-  echo 'yuhao_single_char_only_for_full_code = require("yuhao/yuhao_single_char_only_for_full_code")' >> ${DST_PATH}/rime.lua && \
-  echo 'yuhao_postpone_full_code = require("yuhao/yuhao_postpone_full_code")' >> ${DST_PATH}/rime.lua && \
-  echo 'yuhao_helper = require("yuhao/yuhao_helper")' >> ${DST_PATH}/rime.lua
-  echo 'local temp = require("yuhao/yuhao_chaifen")' >> ${DST_PATH}/rime.lua
-  echo 'yuhao_chaifen = temp.filter' >> ${DST_PATH}/rime.lua
-  echo 'yuhao_chaifen_processor = temp.processor' >> ${DST_PATH}/rime.lua
-  echo 'yuhao_embeded_cands = require("yuhao.yuhao_embeded_cands")' >> ${DST_PATH}/rime.lua
+  cat $OUTPUT/.yuhao/dist/yuhao/schema/rime.lua >> ${DST_PATH}/rime.lua
 
 # 绘文字
 # 方案来源: https://github.com/rime/rime-emoji

--- a/build.sh
+++ b/build.sh
@@ -81,7 +81,6 @@ rm -rf $OUTPUT/.rime_jd && \
 
 # 星猫键道
 # 方案来源: https://github.com/wzxmer/xkjd6-rime
-# 方案来源: https://github.com/wzxmer/xkjd6-rime
 rm -rf $OUTPUT/.xmjd6 && \
   git clone --depth 1 https://github.com/wzxmer/xkjd6-rime $OUTPUT/.xmjd6 && (
     cd $OUTPUT/.xmjd6/xmjd6-Hamster

--- a/build.sh
+++ b/build.sh
@@ -96,11 +96,11 @@ rm -rf $OUTPUT/.xmjd6 && \
 # 方案来源：https://github.com/forFudan/yuhao
 rm -rf $OUTPUT/.yuhao && \
   git clone --depth 1 https://github.com/forFudan/yuhao $OUTPUT/.yuhao && (
-    cd $OUTPUT/.yuhao/schema
+    cd $OUTPUT/.yuhao/beta/schema
     rm -rf default.custom.yaml
   ) &&  \
-  cp $OUTPUT/.yuhao/schema/*.yaml ${DST_PATH} && \
-  cp -r $OUTPUT/.yuhao/schema/lua/* ${DST_PATH}/lua/ && \
+  cp $OUTPUT/.yuhao/beta/schema/*.yaml ${DST_PATH} && \
+  cp -r $OUTPUT/.yuhao/beta/schema/lua/* ${DST_PATH}/lua/ && \
   echo '' >> ${DST_PATH}/rime.lua && \
   echo '-- 宇浩输入法' >> ${DST_PATH}/rime.lua && \
   echo 'yuhao_char_filter = require("yuhao/yuhao_char_filter")' >> ${DST_PATH}/rime.lua && \
@@ -109,9 +109,10 @@ rm -rf $OUTPUT/.yuhao && \
   echo 'yuhao_single_char_only_for_full_code = require("yuhao/yuhao_single_char_only_for_full_code")' >> ${DST_PATH}/rime.lua && \
   echo 'yuhao_postpone_full_code = require("yuhao/yuhao_postpone_full_code")' >> ${DST_PATH}/rime.lua && \
   echo 'yuhao_helper = require("yuhao/yuhao_helper")' >> ${DST_PATH}/rime.lua
-  echo 'temp = require("yuhao/yuhao_chaifen")' >> ${DST_PATH}/rime.lua
+  echo 'local temp = require("yuhao/yuhao_chaifen")' >> ${DST_PATH}/rime.lua
   echo 'yuhao_chaifen = temp.filter' >> ${DST_PATH}/rime.lua
   echo 'yuhao_chaifen_processor = temp.processor' >> ${DST_PATH}/rime.lua
+  echo 'yuhao_embeded_cands = require("yuhao.yuhao_embeded_cands")' >> ${DST_PATH}/rime.lua
 
 # 整理 DST_PATH 输入方案文件, 生成最终版版本default.yaml
 pushd "${DST_PATH}" > /dev/null

--- a/build.sh
+++ b/build.sh
@@ -101,8 +101,8 @@ rm -rf $OUTPUT/.yuhao && \
     cd $OUTPUT/.yuhao/beta/schema
     rm -rf default.custom.yaml
   ) &&  \
-  cp $OUTPUT/.yuhao/schema/*.yaml ${DST_PATH} && \
-  cp -r $OUTPUT/.yuhao/schema/lua/* ${DST_PATH}/lua/ && \
+  cp $OUTPUT/.yuhao/beta/schema/*.yaml ${DST_PATH} && \
+  cp -r $OUTPUT/.yuhao/beta/schema/lua/* ${DST_PATH}/lua/ && \
   echo '' >> ${DST_PATH}/rime.lua && \
   echo '-- 宇浩输入法' >> ${DST_PATH}/rime.lua && \
   echo 'yuhao_char_filter = require("yuhao/yuhao_char_filter")' >> ${DST_PATH}/rime.lua && \
@@ -111,9 +111,10 @@ rm -rf $OUTPUT/.yuhao && \
   echo 'yuhao_single_char_only_for_full_code = require("yuhao/yuhao_single_char_only_for_full_code")' >> ${DST_PATH}/rime.lua && \
   echo 'yuhao_postpone_full_code = require("yuhao/yuhao_postpone_full_code")' >> ${DST_PATH}/rime.lua && \
   echo 'yuhao_helper = require("yuhao/yuhao_helper")' >> ${DST_PATH}/rime.lua
-  echo 'temp = require("yuhao/yuhao_chaifen")' >> ${DST_PATH}/rime.lua
+  echo 'local temp = require("yuhao/yuhao_chaifen")' >> ${DST_PATH}/rime.lua
   echo 'yuhao_chaifen = temp.filter' >> ${DST_PATH}/rime.lua
   echo 'yuhao_chaifen_processor = temp.processor' >> ${DST_PATH}/rime.lua
+  echo 'yuhao_embeded_cands = require("yuhao.yuhao_embeded_cands")' >> ${DST_PATH}/rime.lua
 
 # 绘文字
 # 方案来源: https://github.com/rime/rime-emoji

--- a/build.sh
+++ b/build.sh
@@ -80,7 +80,7 @@ rm -rf $OUTPUT/.rime_jd && \
   cat $OUTPUT/.rime_jd/rime.lua >> ${DST_PATH}/rime.lua
 
 # 星猫键道
-# 方案来源: https://github.com/wzxmer/xkjd6-rime 
+# 方案来源: https://github.com/wzxmer/xkjd6-rime
 rm -rf $OUTPUT/.xmjd6 && \
   git clone --depth 1 https://github.com/wzxmer/xkjd6-rime $OUTPUT/.xmjd6 && (
     cd $OUTPUT/.xmjd6/xmjd6-Hamster

--- a/build.sh
+++ b/build.sh
@@ -134,10 +134,12 @@ pushd "${DST_PATH}" > /dev/null
 
 # 隐藏五笔方案依赖的pinyin_simp.schema.yaml
 # 隐藏星猫键道方案依赖的xmjd6.dz/cx/W/Y/Z/en
+# 隐藏宇浩输入法依赖的yuhao_pinyin.schema.yaml
 ls *.schema.yaml | grep -v pinyin_simp.schema.yaml | grep -v liangfen.schema.yaml \
   | grep -v xmjd6.en.schema.yaml | grep -v xmjd6.dz.schema.yaml \
   | grep -v xmjd6.cx.schema.yaml | grep -v xmjd6.W.schema.yaml \
   | grep -v xmjd6.Y.schema.yaml | grep -v xmjd6.Z.schema.yaml \
+  | grep -v yuhao_pinyin.schema.yaml \
   | sed 's/^\(.*\)\.schema\.yaml/  - schema: \1/' > schema_list.yaml
 # 这里不需要只替换luna_pinyin
 # grep -Ff schema_list.yaml default.yaml > schema_list.yaml.min

--- a/build.sh
+++ b/build.sh
@@ -101,7 +101,7 @@ rm -rf $OUTPUT/.yuhao && \
   ) &&  \
   cp $OUTPUT/.yuhao/schema/*.yaml ${DST_PATH} && \
   cp -r $OUTPUT/.yuhao/schema/lua/* ${DST_PATH}/lua/ && \
-  cp $OUTPUT/.yuhao/schema/opencc/* ${DST_PATH}/opencc/ && \
+  echo '' >> ${DST_PATH}/rime.lua && \
   echo '-- 宇浩输入法' >> ${DST_PATH}/rime.lua && \
   echo 'yuhao_char_filter = require("yuhao/yuhao_char_filter")' >> ${DST_PATH}/rime.lua && \
   echo 'yuhao_char_first = yuhao_char_filter.yuhao_char_first' >> ${DST_PATH}/rime.lua && \
@@ -109,6 +109,9 @@ rm -rf $OUTPUT/.yuhao && \
   echo 'yuhao_single_char_only_for_full_code = require("yuhao/yuhao_single_char_only_for_full_code")' >> ${DST_PATH}/rime.lua && \
   echo 'yuhao_postpone_full_code = require("yuhao/yuhao_postpone_full_code")' >> ${DST_PATH}/rime.lua && \
   echo 'yuhao_helper = require("yuhao/yuhao_helper")' >> ${DST_PATH}/rime.lua
+  echo 'temp = require("yuhao/yuhao_chaifen")' >> ${DST_PATH}/rime.lua
+  echo 'yuhao_chaifen = temp.filter' >> ${DST_PATH}/rime.lua
+  echo 'yuhao_chaifen_processor = temp.processor' >> ${DST_PATH}/rime.lua
 
 # 整理 DST_PATH 输入方案文件, 生成最终版版本default.yaml
 pushd "${DST_PATH}" > /dev/null
@@ -134,12 +137,12 @@ pushd "${DST_PATH}" > /dev/null
 
 # 隐藏五笔方案依赖的pinyin_simp.schema.yaml
 # 隐藏星猫键道方案依赖的xmjd6.dz/cx/W/Y/Z/en
-# 隐藏宇浩输入法依赖的yuhao_pinyin.schema.yaml
+# 隐藏宇浩输入法依赖的 yuhao_pinyin / yuhao_chaifen
 ls *.schema.yaml | grep -v pinyin_simp.schema.yaml | grep -v liangfen.schema.yaml \
   | grep -v xmjd6.en.schema.yaml | grep -v xmjd6.dz.schema.yaml \
   | grep -v xmjd6.cx.schema.yaml | grep -v xmjd6.W.schema.yaml \
   | grep -v xmjd6.Y.schema.yaml | grep -v xmjd6.Z.schema.yaml \
-  | grep -v yuhao_pinyin.schema.yaml \
+  | grep -v yuhao_pinyin.schema.yaml | grep -v yuhao_chaifen.schema.yaml \
   | sed 's/^\(.*\)\.schema\.yaml/  - schema: \1/' > schema_list.yaml
 # 这里不需要只替换luna_pinyin
 # grep -Ff schema_list.yaml default.yaml > schema_list.yaml.min


### PR DESCRIPTION
宇浩输入法的 lua 更新後，增加了兩行 rime.lua。目前，使用的是 echo 按行貼入 rime.lua，這是不科學的。故而改爲使用 cat 而非 echo 貼入 rime.lua，避免代碼冗長。